### PR TITLE
Beta redirects

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,69 +9,82 @@ const util = require('./util');
  */
 module.exports = class Proxy {
 
-  constructor(host, useHttps = true) {
+  constructor(host, rewrite, useHttps = true) {
     this.host = host;
+    this.rewrite = rewrite;
     this.protocol = useHttps ? https : http;
   }
 
-  request(event, pathReplace, pathReplaceWith) {
-    return new Promise((resolve, reject) => {
-      let opts = this.eventToOptions(event);
-      let originalPath, requestBody;
-      if (pathReplace && pathReplaceWith) {
-        originalPath = opts.path;
-        opts.path = opts.path.replace(pathReplace, pathReplaceWith);
-      }
+  request(event) {
+    if (this.rewrite) {
+      return this.rewrite(event.path).then(newPath => {
+        return this._request(event, newPath);
+      });
+    } else {
+      return this._request(event);
+    }
+  }
+
+  request(event) {
+    return this.eventToOptions(event).then(opts => {
+      let requestBody;
       if (event.body) {
         requestBody = event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body;
       }
-      this._request(opts, requestBody, (err, resp, responseBody) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve({
-            method: opts.method,
-            path: opts.path,
-            originalPath: originalPath,
-            status: resp.statusCode,
-            headers: util.keysToLowerCase(resp.headers || {}),
-            body: responseBody ? responseBody.toString('base64') : null
-          });
-        }
-      });
+      return this._request(opts, requestBody);
+    }).then(([resp, responseBody]) => {
+      return {
+        statusCode: resp.statusCode,
+        headers: util.keysToLowerCase(resp.headers || {}),
+        body: responseBody ? responseBody.toString('base64') : null,
+        isBase64Encoded: true
+      };
     });
   }
 
   eventToOptions(event) {
-    let opts = {};
-    opts.hostname = this.host;
-    opts.method = event.httpMethod;
-    opts.path = event.path;
-    Object.keys(event.queryStringParameters || {}).forEach(key => {
-      const sep = (opts.path.indexOf('?') === -1) ? '?' : '&';
-      const val = event.queryStringParameters[key];
-      if (val === '') {
-        opts.path += sep + encodeURIComponent(key);
+    return new Promise((resolve, reject) => {
+      let opts = {};
+      opts.hostname = this.host;
+      opts.method = event.httpMethod;
+      opts.path = event.path;
+      Object.keys(event.queryStringParameters || {}).forEach(key => {
+        const sep = (opts.path.indexOf('?') === -1) ? '?' : '&';
+        const val = event.queryStringParameters[key];
+        if (val === '') {
+          opts.path += sep + encodeURIComponent(key);
+        } else {
+          opts.path += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+        }
+      });
+      opts.headers = util.keysToLowerCase(event.headers);
+      delete opts.headers.host;
+
+      // optionally rewrite path
+      if (this.rewrite) {
+        return this.rewrite(opts.path).then(newPath => {
+          opts.path = newPath;
+          resolve(opts);
+        });
       } else {
-        opts.path += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+        resolve(opts);
       }
     });
-    opts.headers = util.keysToLowerCase(event.headers);
-    delete opts.headers.host;
-    return opts;
   }
 
-  _request(opts, body, callback) {
-    const req = this.protocol.request(opts, resp => {
-      let data = [];
-      resp.on('data', chunk => data.push(chunk));
-      resp.on('end', () => callback(null, resp, data.length ? Buffer.concat(data) : null));
+  _request(opts, body) {
+    return new Promise((resolve, reject) => {
+      const req = this.protocol.request(opts, resp => {
+        let data = [];
+        resp.on('data', chunk => data.push(chunk));
+        resp.on('end', () => resolve([resp, data.length ? Buffer.concat(data) : null]));
+      });
+      req.on('error', err => reject(err));
+      if (body) {
+        req.write(body);
+      }
+      req.end();
     });
-    req.on('error', err => callback(err));
-    if (body) {
-      req.write(body);
-    }
-    req.end();
   }
 
 }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -47,16 +47,7 @@ module.exports = class Proxy {
       let opts = {};
       opts.hostname = this.host;
       opts.method = event.httpMethod;
-      opts.path = event.path;
-      Object.keys(event.queryStringParameters || {}).forEach(key => {
-        const sep = (opts.path.indexOf('?') === -1) ? '?' : '&';
-        const val = event.queryStringParameters[key];
-        if (val === '') {
-          opts.path += sep + encodeURIComponent(key);
-        } else {
-          opts.path += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
-        }
-      });
+      opts.path = event.path + util.queryToString(event.queryStringParameters);
       opts.headers = util.keysToLowerCase(event.headers);
       delete opts.headers.host;
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -16,16 +16,6 @@ module.exports = class Proxy {
   }
 
   request(event) {
-    if (this.rewrite) {
-      return this.rewrite(event.path).then(newPath => {
-        return this._request(event, newPath);
-      });
-    } else {
-      return this._request(event);
-    }
-  }
-
-  request(event) {
     return this.eventToOptions(event).then(opts => {
       let requestBody;
       if (event.body) {

--- a/lib/proxy.test.js
+++ b/lib/proxy.test.js
@@ -5,34 +5,32 @@ const Proxy = require('./proxy');
 
 describe('proxy', () => {
 
-  const proxy = new Proxy('foo.bar');
+  const rewrite = path => Promise.resolve(path === '/re/write' ? '/re/written' : path);
+  const proxy = new Proxy('foo.bar', rewrite);
 
   it('returns the proxied resource', () => {
     nock('https://foo.bar').get('/thing').reply(200, 'what ever', {'Header': 'value'});
     return proxy.request({httpMethod: 'GET', path: '/thing', headers: {}}).then(resp => {
-      expect(resp.method).toEqual('GET');
-      expect(resp.path).toEqual('/thing');
-      expect(resp.status).toEqual(200);
+      expect(resp.statusCode).toEqual(200);
       expect(resp.headers).toEqual({header: 'value'});
+      expect(resp.isBase64Encoded).toEqual(true);
       expect(Buffer.from(resp.body, 'base64').toString()).toEqual('what ever');
     });
   });
 
   it('rewrites paths', () => {
-    nock('https://foo.bar').get('/hello/world').reply(200, 'hello world');
-    const event = {httpMethod: 'GET', path: '/thing', headers: {}};
-    return proxy.request(event, /thing/, 'hello/world').then(resp => {
-      expect(resp.method).toEqual('GET');
-      expect(resp.path).toEqual('/hello/world');
-      expect(resp.originalPath).toEqual('/thing');
-      expect(resp.status).toEqual(200);
+    nock('https://foo.bar').get('/re/written').reply(200, 'hello world');
+    const event = {httpMethod: 'GET', path: '/re/write', headers: {}};
+    return proxy.request(event).then(resp => {
+      expect(resp.statusCode).toEqual(200);
       expect(resp.headers).toEqual({});
+      expect(resp.isBase64Encoded).toEqual(true);
       expect(Buffer.from(resp.body, 'base64').toString()).toEqual('hello world');
     });
   });
 
   it('passes query params', () => {
-    nock('https://foo.bar')
+    const scope = nock('https://foo.bar')
       .get('/thing')
       .query(obj => {
         expect(obj.hello).toEqual('world')
@@ -42,15 +40,15 @@ describe('proxy', () => {
       .reply(200, 'what ever');
     const event = {httpMethod: 'GET', path: '/thing', headers: {}, queryStringParameters: {hello: 'world', foo: ''}};
     return proxy.request(event).then(resp => {
-      expect(resp.path).toEqual('/thing?hello=world&foo');
+      expect(scope.isDone()).toEqual(true);
     });
   });
 
   it('passes request headers', () => {
-    nock('https://foo.bar', {reqheaders: {'foo': 'bar'}}).get('/thing').reply(200, 'what ever');
+    const scope = nock('https://foo.bar', {reqheaders: {'foo': 'bar'}}).get('/thing').reply(200, 'what ever');
     const event = {httpMethod: 'GET', path: '/thing', headers: {'Foo': 'bar'}};
     return proxy.request(event).then(resp => {
-      expect(resp.path).toEqual('/thing');
+      expect(scope.isDone()).toEqual(true);
     });
   });
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('./util');
+
 /**
  * Return a redirect
  */
@@ -22,16 +24,8 @@ module.exports = class Proxy {
   }
 
   _request(event, path) {
-    let loc = `${this.protocol}://${this.host}${path || ''}`;
-    Object.keys(event.queryStringParameters || {}).forEach(key => {
-      const sep = (loc.indexOf('?') === -1) ? '?' : '&';
-      const val = event.queryStringParameters[key];
-      if (val === '') {
-        loc += sep + encodeURIComponent(key);
-      } else {
-        loc += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
-      }
-    });
+    const query = util.queryToString(event.queryStringParameters);
+    const loc = `${this.protocol}://${this.host}${path || ''}${query}`;
     return Promise.resolve({
       statusCode: 302,
       headers: {'location': loc, 'content-type': 'text/plain', },

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -5,18 +5,24 @@
  */
 module.exports = class Proxy {
 
-  constructor(host, useHttps = true) {
+  constructor(host, rewrite, useHttps = true) {
     this.host = host;
+    this.rewrite = rewrite;
     this.protocol = useHttps ? 'https' : 'http';
   }
 
-  redirect(event, pathReplace, pathReplaceWith) {
-    let loc = `${this.protocol}://${this.host}`;
-    if (pathReplace && pathReplaceWith) {
-      loc += event.path.replace(pathReplace, pathReplaceWith);
+  request(event) {
+    if (this.rewrite) {
+      return this.rewrite(event.path).then(newPath => {
+        return this._request(event, newPath);
+      });
     } else {
-      loc += event.path;
+      return this._request(event, event.path);
     }
+  }
+
+  _request(event, path) {
+    let loc = `${this.protocol}://${this.host}${path || ''}`;
     Object.keys(event.queryStringParameters || {}).forEach(key => {
       const sep = (loc.indexOf('?') === -1) ? '?' : '&';
       const val = event.queryStringParameters[key];
@@ -26,11 +32,11 @@ module.exports = class Proxy {
         loc += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
       }
     });
-    return {
+    return Promise.resolve({
       statusCode: 302,
       headers: {'location': loc, 'content-type': 'text/plain', },
       body: `Moved to ${loc}`
-    };
+    });
   }
 
 }

--- a/lib/redirect.test.js
+++ b/lib/redirect.test.js
@@ -4,39 +4,45 @@ const Redirect = require('./redirect');
 
 describe('redirect', () => {
 
-  const redirect = new Redirect('foo.bar.gov');
+  const rewrite = path => Promise.resolve(path === '/re/write' ? '/re/written' : path);
+  const redirect = new Redirect('foo.bar.gov', rewrite);
 
   it('returns a redirect', () => {
-    const resp = redirect.redirect({path: '/hello/world'});
-    expect(resp.statusCode).toEqual(302);
-    expect(resp.headers['content-type']).toEqual('text/plain');
-    expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world');
-    expect(resp.body).toEqual('Moved to https://foo.bar.gov/hello/world');
+    return redirect.request({path: '/hello/world'}).then(resp => {
+      expect(resp.statusCode).toEqual(302);
+      expect(resp.headers['content-type']).toEqual('text/plain');
+      expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world');
+      expect(resp.body).toEqual('Moved to https://foo.bar.gov/hello/world');
+    });
   });
 
   it('adds query params', () => {
-    const resp = redirect.redirect({path: '/hello/world', queryStringParameters: {foo: 'bar%'}});
-    expect(resp.statusCode).toEqual(302);
-    expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world?foo=bar%25');
+    return redirect.request({path: '/hello/world', queryStringParameters: {foo: 'bar%'}}).then(resp => {
+      expect(resp.statusCode).toEqual(302);
+      expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world?foo=bar%25');
+    });
   });
 
   it('recognizes blank query params', () => {
-    const resp = redirect.redirect({path: '/', queryStringParameters: {foo: '1', bar: '', one: ''}});
-    expect(resp.statusCode).toEqual(302);
-    expect(resp.headers.location).toEqual('https://foo.bar.gov/?foo=1&bar&one');
+    return redirect.request({path: '/', queryStringParameters: {foo: '1', bar: '', one: ''}}).then(resp => {
+      expect(resp.statusCode).toEqual(302);
+      expect(resp.headers.location).toEqual('https://foo.bar.gov/?foo=1&bar&one');
+    });
   });
 
   it('can be non-https', () => {
-    const redirect2 = new Redirect('foo.bar.gov', false);
-    const resp = redirect2.redirect({path: '/hello/world'});
-    expect(resp.statusCode).toEqual(302);
-    expect(resp.headers.location).toEqual('http://foo.bar.gov/hello/world');
+    const redirect2 = new Redirect('foo.bar.gov', null, false);
+    return redirect2.request({path: '/hello/world'}).then(resp => {
+      expect(resp.statusCode).toEqual(302);
+      expect(resp.headers.location).toEqual('http://foo.bar.gov/hello/world');
+    });
   });
 
   it('rewrites a path', () => {
-    const resp = redirect.redirect({path: '/hello/world'}, /Hello/i, 'foobar');
-    expect(resp.statusCode).toEqual(302);
-    expect(resp.headers.location).toEqual('https://foo.bar.gov/foobar/world');
+    return redirect.request({path: '/re/write'}, /Hello/i, 'foobar').then(resp => {
+      expect(resp.statusCode).toEqual(302);
+      expect(resp.headers.location).toEqual('https://foo.bar.gov/re/written');
+    });
   });
 
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,7 @@ const binaryCase = require('binary-case');
 const prxSessionKey = process.env.PRX_SESSION_KEY || '_prx_session';
 
 const MOBILE_REGEX = /iphone|ipad|ipod|android|blackberry|mini|windows\sce|palm/i;
-const MOBILE_SITE_REGEX = /beta\.prx\.org|localhost/i;
+const MOBILE_SITE_REGEX = /beta\.prx\.|listen\.prx\.|localhost/i;
 const ROBOT_REGEX = /googlebot|baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|bingbot/i;
 
 /**
@@ -21,6 +21,27 @@ exports.isLoggedIn = (cookieStr) => {
  */
 exports.isCrawler = (userAgent) => {
   return ROBOT_REGEX.test(userAgent || '');
+};
+
+/**
+ * Check if a user agent looks like a mobile device
+ */
+exports.isMobile = (userAgent) => {
+  return MOBILE_REGEX.test(userAgent || '');
+};
+
+/**
+ * Sometimes you just can't go back
+ */
+exports.hatesMobileSite = (referrer, queryParams) => {
+  const mParam = (queryParams || {})['m'];
+  if (MOBILE_SITE_REGEX.test(referrer || '')) {
+    return true;
+  } else if ([0, '0', false, 'false'].indexOf(mParam) > -1) {
+    return true;
+  } else {
+    return false;
+  }
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -72,3 +72,20 @@ exports.keysToLowerCase = (obj) => {
     return obj;
   }
 };
+
+/**
+ * Convert an object into an actual query string
+ */
+exports.queryToString = (obj) => {
+  let str = '';
+  Object.keys(obj || {}).forEach(key => {
+    const sep = (str.indexOf('?') === -1) ? '?' : '&';
+    const val = obj[key];
+    if (val === '') {
+      str += sep + encodeURIComponent(key);
+    } else {
+      str += sep + encodeURIComponent(key) + '=' + encodeURIComponent(val);
+    }
+  });
+  return str;
+};

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -18,6 +18,22 @@ describe('util', () => {
     expect(util.isCrawler('Mozilla/5.0 (compatible; Bingbot/2.0; +http://www.bing.com/bingbot.htm)')).toEqual(true);
   });
 
+  it('recognizes mobile', () => {
+    expect(util.isMobile()).toEqual(false);
+    expect(util.isMobile('')).toEqual(false);
+    expect(util.isMobile('Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25')).toEqual(true);
+    expect(util.isMobile('Mozilla/5.0 (Linux; Android 4.4; Nexus 5 Build/_BuildID_) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36')).toEqual(true);
+    expect(util.isMobile('Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.450 Mobile Safari/534.8+')).toEqual(true);
+  });
+
+  it('knows how much you hate the mobile site', () => {
+    expect(util.hatesMobileSite()).toEqual(false);
+    expect(util.hatesMobileSite('https://beta.prx.org/what/ever')).toEqual(true);
+    expect(util.hatesMobileSite('http://listen.prx.org/what/ever')).toEqual(true);
+    expect(util.hatesMobileSite(null, {m: '0'})).toEqual(true);
+    expect(util.hatesMobileSite(null, {m: 0})).toEqual(true);
+  });
+
   it('lowercases keys', () => {
     expect(util.keysToLowerCase()).toEqual(undefined);
     expect(util.keysToLowerCase({})).toEqual({});

--- a/routes/exchange-proxy.js
+++ b/routes/exchange-proxy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Paths proxied to exchange
  */

--- a/routes/exchange-redirect.js
+++ b/routes/exchange-redirect.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Paths redirected to exchange
  */

--- a/routes/listen-redirect.js
+++ b/routes/listen-redirect.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// helper to make a regexp-like matcher
+function makeMatcher(regex, a, b, c, d) {
+  return {
+    test: (path, loggedIn, isCrawler, isMobile, hatesBeta) => {
+      return regex.test(path)
+        && (a === null || loggedIn === a)
+        && (b === null || isCrawler === b)
+        && (c === null || isMobile === c)
+        && (d === null || hatesBeta === d);
+    }
+  }
+}
+
+/**
+ * Paths (plus other state matchers) redirected to listen
+ */
+module.exports = [
+  makeMatcher(/^\/pieces\//, false, false, null, false),
+  makeMatcher(/^\/accounts\//, false, null, true, false),
+  makeMatcher(/^\/group_accounts\//, false, null, true, false),
+  makeMatcher(/^\/individual_accounts\//, false, null, true, false),
+  makeMatcher(/^\/station_accounts\//, false, null, true, false),
+  makeMatcher(/^\/users\//, false, null, true, false)
+];

--- a/routes/listen-redirect.test.js
+++ b/routes/listen-redirect.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const redirect = require('./listen-redirect');
+const makeTester = (loggedIn, isCrawler, isMobile, hatesBeta) => {
+  return path => {
+    return redirect.some(r => r.test(path, loggedIn, isCrawler, isMobile, hatesBeta));
+  };
+};
+
+describe('listen-redirect', () => {
+
+  it('redirects non logged in users to pieces only', () => {
+    const tester = makeTester(false, false, false, false);
+    expect(tester('/pieces/1234')).toEqual(true);
+    expect(tester('/accounts/1234')).toEqual(false);
+    expect(tester('/group_accounts/1234')).toEqual(false);
+    expect(tester('/individual_accounts/1234')).toEqual(false);
+    expect(tester('/station_accounts/1234')).toEqual(false);
+    expect(tester('/users/1234')).toEqual(false);
+  });
+
+  it('does not redirect logged in users', () => {
+    const tester = makeTester(true, false, false, false);
+    expect(tester('/pieces/1234')).toEqual(false);
+    expect(tester('/accounts/1234')).toEqual(false);
+    expect(tester('/group_accounts/1234')).toEqual(false);
+    expect(tester('/individual_accounts/1234')).toEqual(false);
+    expect(tester('/station_accounts/1234')).toEqual(false);
+    expect(tester('/users/1234')).toEqual(false);
+  });
+
+  it('does not redirect crawlers', () => {
+    const tester = makeTester(false, true, false, false);
+    expect(tester('/pieces/1234')).toEqual(false);
+    expect(tester('/accounts/1234')).toEqual(false);
+    expect(tester('/group_accounts/1234')).toEqual(false);
+    expect(tester('/individual_accounts/1234')).toEqual(false);
+    expect(tester('/station_accounts/1234')).toEqual(false);
+    expect(tester('/users/1234')).toEqual(false);
+  });
+
+  it('redirects mobile users for most pages', () => {
+    const tester = makeTester(false, false, true, false);
+    expect(tester('/pieces/1234')).toEqual(true);
+    expect(tester('/accounts/1234')).toEqual(true);
+    expect(tester('/group_accounts/1234')).toEqual(true);
+    expect(tester('/individual_accounts/1234')).toEqual(true);
+    expect(tester('/station_accounts/1234')).toEqual(true);
+    expect(tester('/users/1234')).toEqual(true);
+  });
+
+  it('does not redirect users coming from beta', () => {
+    const tester = makeTester(false, false, true, true);
+    expect(tester('/pieces/1234')).toEqual(false);
+    expect(tester('/accounts/1234')).toEqual(false);
+    expect(tester('/group_accounts/1234')).toEqual(false);
+    expect(tester('/individual_accounts/1234')).toEqual(false);
+    expect(tester('/station_accounts/1234')).toEqual(false);
+    expect(tester('/users/1234')).toEqual(false);
+  });
+
+});

--- a/routes/listen-rewrite.js
+++ b/routes/listen-rewrite.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const https = require('https');
+const CMS_HOST = process.env.CMS_HOST || 'cms.prx.org';
+
+const PIECES = /^\/pieces\//;
+const ACCOUNTS = /^\/([a-z]+_)?accounts\//;
+const USERS = /^\/users\/([0-9]+)/;
+
+/**
+ * Rewrite piece/account paths
+ */
+module.exports = (path) => {
+  if (PIECES.test(path)) {
+    return Promise.resolve(path.replace(PIECES, '/stories/'));
+  } else if (ACCOUNTS.test(path)) {
+    return Promise.resolve(path.replace(ACCOUNTS, '/accounts/'));
+  } else if (USERS.test(path)) {
+    const userId = path.match(USERS)[1];
+    return cmsGet(`/api/v1/users/${userId}?zoom=prx:default-account`).then(json => {
+      const defaultAccount = json['_links']['prx:default-account']['href'];
+      const accountId = defaultAccount.split('/').pop();
+      return `/accounts/${accountId}`;
+    }).catch(err => {
+      return path;
+    });
+  } else {
+    return Promise.resolve(path);
+  }
+};
+
+/**
+ * Get some CMS data
+ */
+function cmsGet(path) {
+  return new Promise((resolve, reject) => {
+    const url = `https://${CMS_HOST}${path}`;
+    https.get(url, resp => {
+      if (resp.statusCode === 200) {
+        let data = [];
+        resp.on('data', chunk => data.push(chunk));
+        resp.on('end', () => {
+          const buffer = Buffer.concat(data).toString('utf-8');
+          try {
+            resolve(JSON.parse(buffer));
+          } catch (err) {
+            reject(new Error('Invalid response json'));
+          }
+        });
+      } else {
+        reject(new Error(`Got ${resp.statusCode} for url: ${url}`));
+      }
+    }).on('error', err => reject(err));
+  });
+}

--- a/routes/listen-rewrite.test.js
+++ b/routes/listen-rewrite.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const rewrite = require('./listen-rewrite');
+const nock = require('nock');
+
+describe('listen-rewrite', () => {
+
+  test('ignores unknown paths', () => {
+    return rewrite('/foo/1234').then(path => {
+      expect(path).toEqual('/foo/1234');
+    });
+  });
+
+  test('rewrites pieces to stories', () => {
+    return rewrite('/pieces/1234').then(path => {
+      expect(path).toEqual('/stories/1234');
+    });
+  });
+
+  test('rewrites account types', () => {
+    return rewrite('/accounts/123').then(path => {
+      expect(path).toEqual('/accounts/123');
+      return rewrite('/group_accounts/456');
+    }).then(path => {
+      expect(path).toEqual('/accounts/456');
+      return rewrite('/individual_accounts/789');
+    }).then(path => {
+      expect(path).toEqual('/accounts/789');
+      return rewrite('/station_accounts/101112');
+    }).then(path => {
+      expect(path).toEqual('/accounts/101112');
+    });
+  });
+
+  test('rewrites users to their default account', () => {
+    const user = {_links: {'prx:default-account': {href: '/api/v1/accounts/5678'}}}
+    nock('https://cms.prx.org').get('/api/v1/users/1234').query(q => true).reply(200, JSON.stringify(user));
+    nock('https://cms.prx.org').get('/api/v1/users/4321').query(q => true).reply(500);
+    return rewrite('/users/1234').then(path => {
+      expect(path).toEqual('/accounts/5678');
+      return rewrite('/users/4321');
+    }).then(path => {
+      expect(path).toEqual('/users/4321');
+    });
+  });
+
+});


### PR DESCRIPTION
See #6.

- [x] Do the same redirects to beta as exchange does
- [x] Lookup the default-account id for a user id, so we can redirect to it (there is no `/users/1234` page in beta)
- [x] Redirect non-canonical hosts (such as `prx.org`) to the default host `www.prx.org`.