### PR TITLE
Logging fixes

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -5,7 +5,7 @@ const util = require('./util');
 /**
  * Return a redirect
  */
-module.exports = class Proxy {
+module.exports = class Redirect {
 
   constructor(host, rewrite, useHttps = true) {
     this.host = host;

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,15 +56,15 @@ exports.keysToLowerCase = (obj) => {
       const val = obj[k];
       if (typeof(val) === 'string') {
         lower[key] = val;
-      } else if (Array.isArray(val) && val.length === 1) {
+      } else if (val && val.length === 1) {
         lower[key] = val[0];
-      } else if (Array.isArray(val)) {
+      } else if (val && val.length > 1 && val.forEach) {
         const iterator = binaryCase.iterator(key);
         val.forEach(subVal => {
           lower[iterator.next().value] = subVal;
         });
       } else {
-        console.warn('WARN: unknown header value', k, typeof obj[k], obj[k]);
+        console.warn('[WARN] unknown header value', k, typeof obj[k], obj[k]);
       }
     });
     return lower;


### PR DESCRIPTION
Small fixes.

- [x] Logger uses constructor name, so make sure it prints `[INFO] Redirect 302` instead of `Proxy`
- [x] Fix log.warn to use brackets
- [x] Strange issue where prod was failing to set-cookie, because `Array.isArray()` wasn't detecting it.  But in the logged output, it was obviously an array.  So fallback to some basic js length checking.