### PR TITLE
PRI domain support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,25 @@ const Proxy = require('./lib/proxy');
 const Redirect = require('./lib/redirect');
 const util = require('./lib/util');
 
+// These are the domains that this application is handling traffic for
 const HOSTS = (process.env.CANONICAL_HOSTS || 'www.prx.org,proxy.prx.org,proxy.staging.prx.tech,localhost:3000').split(',');
+const PRI_HOSTS = ['pri.org', 'www.pri.org'];
 
+// These are the domains that traffic is redirected to or used to fetch data
+// when being proxied. They are NOT domains for traffic being handled by this
+// application.
 const EXCHANGE_HOST = process.env.EXCHANGE_HOST || 'exchange.prx.org';
 const UNBOUNCE_HOST = process.env.UNBOUNCE_HOST || 'try.prx.org';
 const LISTEN_HOST = process.env.LISTEN_HOST || 'beta.prx.org';
 const HELP_HOST = process.env.HELP_HOST || 'help.prx.org';
 const PRI_HOST = process.env.PRI_HOST || 'www.pri.org'
 const CORPORATE_HOST = process.env.CORPORATE_HOST || 'corporate.prx.tech';
-const ROUTES = [
+const THEWORLD_HOST = process.env.THEWORLD_HOST || 'theworld.org';
+const THEWORLD_ADMIN_HOST = process.env.THEWORLD_ADMIN_HOST || 'admin.theworld.org';
+const THEWORLD_FEEDS_HOST = process.env.THEWORLD_FEEDS_HOST || 'feeds.theworld.org';
+const THEWORLD_FILES_HOST = process.env.THEWORLD_FILES_HOST || 'files.theworld.org';
+
+const PRX_ROUTES = [
   [require('./routes/exchange-proxy'), new Proxy(EXCHANGE_HOST)],
   [require('./routes/unbounce-proxy'), new Proxy(UNBOUNCE_HOST)],
   [require('./routes/listen-redirect'), new Redirect(LISTEN_HOST, require('./routes/listen-rewrite'))],
@@ -22,33 +32,52 @@ const ROUTES = [
   [[/./], new Proxy(CORPORATE_HOST)],
 ];
 
+const PRI_ROUTES = [
+  [require('./routes/pri-admin-redirect'), new Redirect(THEWORLD_ADMIN_HOST, null, true, 301)],
+  [require('./routes/pri-feeds-redirect'), new Redirect(THEWORLD_FEEDS_HOST, null, true, 301)],
+  [require('./routes/pri-files-redirect'), new Redirect(THEWORLD_FILES_HOST, null, true, 301)],
+  [[/./], new Redirect(THEWORLD_HOST)],
+]
+
 /**
  * Proxy requests here and there
  */
 exports.handler = function handler(event, context, callback) {
   const headers = util.keysToLowerCase(event.headers);
-  const loggedIn = util.isLoggedIn(headers['cookie']);
-  const isCrawler = util.isCrawler(headers['user-agent']);
-  const isMobile = util.isMobile(headers['user-agent']);
-  const hatesMobile = util.hatesMobileSite(headers['referer'], event.queryStringParameters);
 
-  // make sure we're at a canonical host
-  if (HOSTS.length && headers['host'] && HOSTS.indexOf(headers['host']) === -1) {
-    const loc = `https://${HOSTS[0]}${event.path}${util.queryToString(event.queryStringParameters)}`;
-    return callback(null, {
-      statusCode: 302,
-      headers: {'location': loc, 'content-type': 'text/plain', },
-      body: `Moved to ${loc}`
+  let route;
+
+  if (PRI_HOSTS.includes(headers.host)) {
+    // Handle pri.org traffic
+    PRI_ROUTES.find(([matchers, obj]) => {
+      if (matchers.some(m => m.test(event.path))) {
+        return route = obj;
+      }
+    });
+  } else {
+    // Handle prx.org traffic
+    const loggedIn = util.isLoggedIn(headers['cookie']);
+    const isCrawler = util.isCrawler(headers['user-agent']);
+    const isMobile = util.isMobile(headers['user-agent']);
+    const hatesMobile = util.hatesMobileSite(headers['referer'], event.queryStringParameters);
+
+    // make sure we're at a canonical host
+    if (HOSTS.length && headers['host'] && HOSTS.indexOf(headers['host']) === -1) {
+      const loc = `https://${HOSTS[0]}${event.path}${util.queryToString(event.queryStringParameters)}`;
+      return callback(null, {
+        statusCode: 302,
+        headers: {'location': loc, 'content-type': 'text/plain', },
+        body: `Moved to ${loc}`
+      });
+    }
+
+    // test paths
+    PRX_ROUTES.find(([matchers, obj]) => {
+      if (matchers.some(m => m.test(event.path, loggedIn, isCrawler, isMobile, hatesMobile))) {
+        return route = obj;
+      }
     });
   }
-
-  // test paths
-  let route;
-  ROUTES.find(([matchers, obj]) => {
-    if (matchers.some(m => m.test(event.path, loggedIn, isCrawler, isMobile, hatesMobile))) {
-      return route = obj;
-    }
-  });
 
   // async handle proxying or redirecting
   if (route) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const PRI_ROUTES = [
   [require('./routes/pri-admin-redirect'), new Redirect(THEWORLD_ADMIN_HOST, null, true, 301)],
   [require('./routes/pri-feeds-redirect'), new Redirect(THEWORLD_FEEDS_HOST, null, true, 301)],
   [require('./routes/pri-files-redirect'), new Redirect(THEWORLD_FILES_HOST, null, true, 301)],
-  [[/./], new Redirect(THEWORLD_HOST)],
+  [[/./], new Redirect(THEWORLD_HOST, null, true, 301)],
 ]
 
 /**

--- a/index.js
+++ b/index.js
@@ -52,28 +52,25 @@ exports.handler = function handler(event, context, callback) {
         return route = obj;
       }
     });
-  } else {
+  } else if (HOSTS.includes(headers.host)) {
     // Handle prx.org traffic
     const loggedIn = util.isLoggedIn(headers['cookie']);
     const isCrawler = util.isCrawler(headers['user-agent']);
     const isMobile = util.isMobile(headers['user-agent']);
     const hatesMobile = util.hatesMobileSite(headers['referer'], event.queryStringParameters);
 
-    // make sure we're at a canonical host
-    if (HOSTS.length && headers['host'] && HOSTS.indexOf(headers['host']) === -1) {
-      const loc = `https://${HOSTS[0]}${event.path}${util.queryToString(event.queryStringParameters)}`;
-      return callback(null, {
-        statusCode: 302,
-        headers: {'location': loc, 'content-type': 'text/plain', },
-        body: `Moved to ${loc}`
-      });
-    }
-
     // test paths
     PRX_ROUTES.find(([matchers, obj]) => {
       if (matchers.some(m => m.test(event.path, loggedIn, isCrawler, isMobile, hatesMobile))) {
         return route = obj;
       }
+    });
+  } else {
+    const loc = `https://${HOSTS[0]}${event.path}${util.queryToString(event.queryStringParameters)}`;
+    return callback(null, {
+      statusCode: 302,
+      headers: { 'location': loc, 'content-type': 'text/plain' },
+      body: `Moved to ${loc}`
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const EXCHANGE_HOST = process.env.EXCHANGE_HOST || 'exchange.prx.org';
 const UNBOUNCE_HOST = process.env.UNBOUNCE_HOST || 'try.prx.org';
 const LISTEN_HOST = process.env.LISTEN_HOST || 'beta.prx.org';
 const HELP_HOST = process.env.HELP_HOST || 'help.prx.org';
-const PRI_HOST = process.env.PRI_HOST || 'www.pri.org'
 const CORPORATE_HOST = process.env.CORPORATE_HOST || 'corporate.prx.tech';
 const THEWORLD_HOST = process.env.THEWORLD_HOST || 'theworld.org';
 const THEWORLD_ADMIN_HOST = process.env.THEWORLD_ADMIN_HOST || 'admin.theworld.org';
@@ -28,7 +27,6 @@ const PRX_ROUTES = [
   [require('./routes/listen-redirect'), new Redirect(LISTEN_HOST, require('./routes/listen-rewrite'))],
   [require('./routes/exchange-redirect'), new Redirect(EXCHANGE_HOST)],
   [require('./routes/help-redirect'), new Redirect(HELP_HOST, require('./routes/help-rewrite'))],
-  [require('./routes/pri-redirect'), new Redirect(PRI_HOST)],
   [[/./], new Proxy(CORPORATE_HOST)],
 ];
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -7,10 +7,11 @@ const util = require('./util');
  */
 module.exports = class Redirect {
 
-  constructor(host, rewrite, useHttps = true) {
+  constructor(host, rewrite, useHttps = true, statusCode = 302) {
     this.host = host;
     this.rewrite = rewrite;
     this.protocol = useHttps ? 'https' : 'http';
+    this.statusCode = statusCode;
   }
 
   request(event) {
@@ -27,7 +28,7 @@ module.exports = class Redirect {
     const query = util.queryToString(event.queryStringParameters);
     const loc = `${this.protocol}://${this.host}${path || ''}${query}`;
     return Promise.resolve({
-      statusCode: 302,
+      statusCode: this.statusCode,
       headers: {'location': loc, 'content-type': 'text/plain', },
       body: `Moved to ${loc}`
     });

--- a/lib/redirect.test.js
+++ b/lib/redirect.test.js
@@ -6,10 +6,20 @@ describe('redirect', () => {
 
   const rewrite = path => Promise.resolve(path === '/re/write' ? '/re/written' : path);
   const redirect = new Redirect('foo.bar.gov', rewrite);
+  const redirect301 = new Redirect('foo.bar.gov', rewrite, true, 301);
 
   it('returns a redirect', () => {
     return redirect.request({path: '/hello/world'}).then(resp => {
       expect(resp.statusCode).toEqual(302);
+      expect(resp.headers['content-type']).toEqual('text/plain');
+      expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world');
+      expect(resp.body).toEqual('Moved to https://foo.bar.gov/hello/world');
+    });
+  });
+
+  it('returns a 301 redirect', () => {
+    return redirect301.request({path: '/hello/world'}).then(resp => {
+      expect(resp.statusCode).toEqual(301);
       expect(resp.headers['content-type']).toEqual('text/plain');
       expect(resp.headers.location).toEqual('https://foo.bar.gov/hello/world');
       expect(resp.body).toEqual('Moved to https://foo.bar.gov/hello/world');

--- a/routes/pri-admin-redirect.js
+++ b/routes/pri-admin-redirect.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Paths redirected to The World admin
+ */
+module.exports = [
+  /^\/admin\//,
+  /^\/node\/[\d]\/(edit|moderation|embedded|popout|log)$/,
+  /^\/file\/[\d]+\/(edit|usage|delete)$/,
+  /^\/user\//,
+  /^\/profile\//,
+  /^\/import\//,
+];

--- a/routes/pri-feeds-redirect.js
+++ b/routes/pri-feeds-redirect.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Paths redirected to The World feeds
+ */
+module.exports = [
+  /^\/feeds\?\//,
+  /^.*\/feed\//,
+  /feed$/,
+  /^\/stories\/feed/,
+  /^\/allstories\/feed/,
+  /^\/collections\/[\d]\/feed/,
+  /^\/sections\/[\d]\/feed/,
+  /^\/verticals\/[\d]\/feed/,
+  /^\/verticals-listing\/[\d]\/feed/,
+  /^program\/[\d]\/feed/,
+  /^\/programs\/[\d]\/[\d]\/feed/,
+  /^\/fia\/nodes.rss$/,
+  /^\/social-posts\//,
+];

--- a/routes/pri-files-redirect.js
+++ b/routes/pri-files-redirect.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * Paths redirected to The World files
+ */
+module.exports = [
+  /^\/sites\/default\/files\//,
+  /^\/s3\/files\/(styles|imagecache)\//,
+  /^\/kraken\//,
+];

--- a/routes/pri-redirect.js
+++ b/routes/pri-redirect.js
@@ -1,6 +1,0 @@
-'use strict';
-
-/**
- * Paths redirected to www.pri.org
- */
-module.exports = [];


### PR DESCRIPTION
This (hopefully) adds support to handle traffic to `pri.org` and `www.pri.org`, and redirect **all** of it to either `theworld.org` or a subdomain of theworld.org.

Also allows for redirects to be 301s, rather than 302s.